### PR TITLE
feat: add video meme support

### DIFF
--- a/retard.js
+++ b/retard.js
@@ -140,7 +140,7 @@ async function fetchRandomCopiepate() {
   return random.selftext;
 }
 
-// Meme image (NSFW inclus)
+// Meme image ou vidéo (NSFW inclus)
 // Subreddits utilisés pour la recherche de memes
 const subredditsMemes = [
   'Discordmemes',
@@ -156,10 +156,10 @@ const MAX_HISTORY = 200;
 const subredditCache = {};
 
 /**
- * Récupère l’image d’un meme aléatoire parmi plusieurs subreddits.
+ * Récupère un meme aléatoire (image ou vidéo) parmi plusieurs subreddits.
  * Utilise un cache local pour limiter les requêtes Reddit.
  */
-async function fetchRandomMemeImage() {
+async function fetchRandomMeme() {
   const sub = randomItem(subredditsMemes);
   const now = Date.now();
 
@@ -190,18 +190,43 @@ async function fetchRandomMemeImage() {
   const offset = Math.floor(Math.random() * Math.max(1, posts.length / offsetStep)) * offsetStep;
   const slice = posts.slice(offset, offset + offsetStep);
 
-  const images = slice.filter(
-    post =>
-      post.url &&
-      /\.(jpg|jpeg|png|gif)$/.test(post.url) &&
-      !sentMemes.has(post.url)
-  );
+  const medias = slice
+    .map(post => {
+      const url = post.url || '';
+      if (post.is_video && post.media?.reddit_video?.fallback_url) {
+        return {
+          type: 'video',
+          url: post.media.reddit_video.fallback_url,
+          title: post.title,
+          subreddit: sub,
+        };
+      }
+      if (/\.gifv$/.test(url)) {
+        return {
+          type: 'video',
+          url: url.replace(/\.gifv$/, '.mp4'),
+          title: post.title,
+          subreddit: sub,
+        };
+      }
+      if (/\.(jpg|jpeg|png|gif)$/.test(url)) {
+        return {
+          type: 'image',
+          url,
+          title: post.title,
+          subreddit: sub,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean)
+    .filter(m => !sentMemes.has(m.url));
 
-  if (images.length === 0) return null;
+  if (medias.length === 0) return null;
 
-  const random = randomItem(images);
+  const random = randomItem(medias);
 
-  // Historique pour ne pas renvoyer les mêmes images
+  // Historique pour ne pas renvoyer les mêmes médias
   sentMemes.add(random.url);
   if (sentMemes.size > MAX_HISTORY) {
     const arr = Array.from(sentMemes);
@@ -209,7 +234,7 @@ async function fetchRandomMemeImage() {
     arr.slice(-MAX_HISTORY).forEach(url => sentMemes.add(url));
   }
 
-  return { url: random.url, title: random.title, subreddit: sub };
+  return random;
 }
 
 // Helper pour capitaliser (nécessaire pour appeler `getHot`, `getNew`, etc.)
@@ -347,11 +372,19 @@ Dis bien a ce batard`;
 }
 
   else if (name === 'meme') {
-    const meme = await fetchRandomMemeImage();
+    const meme = await fetchRandomMeme();
     await interaction.deferReply({ ephemeral: true });
     await interaction.deleteReply();
     if (!meme) {
       await interaction.channel.send("https://tenor.com/view/kirby-i-forgot-i-forgor-gif-22449575");
+    } else if (meme.type === 'video') {
+      await interaction.channel.send({
+        content: meme.url,
+        embeds: [{
+          title: meme.title,
+          footer: { text: `r/${meme.subreddit}` }
+        }]
+      });
     } else {
       await interaction.channel.send({
         embeds: [{

--- a/slash.js
+++ b/slash.js
@@ -13,7 +13,7 @@ if (!DISCORD_TOKEN || !CLIENT_ID) {
 const commands = [
   new SlashCommandBuilder().setName('curse').setDescription('Active Curse of Ra'),
   new SlashCommandBuilder().setName('copiepate').setDescription('Reçoit une copiepasta'),
-  new SlashCommandBuilder().setName('meme').setDescription('Reçoit un meme'),
+  new SlashCommandBuilder().setName('meme').setDescription('Reçoit un meme (image ou vidéo)'),
   new SlashCommandBuilder().setName('ascii').setDescription('Envoie un ASCII random'),
   new SlashCommandBuilder()
     .setName('insulte')


### PR DESCRIPTION
## Summary
- allow `/meme` to send Reddit videos by fetching `reddit_video` fallback URLs
- update slash command description for `/meme`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689095e790888333af2730e809da681f