### PR TITLE
feat: add wiki command

### DIFF
--- a/slash.js
+++ b/slash.js
@@ -15,6 +15,7 @@ const commands = [
   new SlashCommandBuilder().setName('copiepate').setDescription('Reçoit une copiepasta'),
   new SlashCommandBuilder().setName('meme').setDescription('Reçoit un meme (image ou vidéo)'),
   new SlashCommandBuilder().setName('ascii').setDescription('Envoie un ASCII random'),
+  new SlashCommandBuilder().setName('wiki').setDescription('Lien Wikipédia lié aux derniers messages'),
   new SlashCommandBuilder()
     .setName('insulte')
     .setDescription("insulte quelqu'un")


### PR DESCRIPTION
## Summary
- add `/wiki` slash command to fetch Wikipedia link related to recent channel messages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68930373094083339f4d5e3a7c9c92c6