### PR TITLE
feat: add search option to wiki command

### DIFF
--- a/slash.js
+++ b/slash.js
@@ -15,7 +15,15 @@ const commands = [
   new SlashCommandBuilder().setName('copiepate').setDescription('Reçoit une copiepasta'),
   new SlashCommandBuilder().setName('meme').setDescription('Reçoit un meme (image ou vidéo)'),
   new SlashCommandBuilder().setName('ascii').setDescription('Envoie un ASCII random'),
-  new SlashCommandBuilder().setName('wiki').setDescription('Lien Wikipédia lié aux derniers messages'),
+  new SlashCommandBuilder()
+    .setName('wiki')
+    .setDescription('Lien Wikipédia lié aux derniers messages ou à une recherche')
+    .addStringOption(option =>
+      option
+        .setName('recherche')
+        .setDescription('Terme à rechercher sur Wikipédia')
+        .setRequired(false)
+    ),
   new SlashCommandBuilder()
     .setName('insulte')
     .setDescription("insulte quelqu'un")


### PR DESCRIPTION
## Summary
- allow `/wiki` to search Wikipedia by optional `recherche` argument
- fall back to last messages when no search term is provided

## Testing
- `node --check retard.js && echo 'retard.js ok'`
- `node --check slash.js && echo 'slash.js ok'`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689446ecacd4833382491e8254f99b34