### PR TITLE
Add 1% ok response to ta gueule trigger

### DIFF
--- a/retard.js
+++ b/retard.js
@@ -375,7 +375,11 @@ client.on('messageCreate', async message => {
 
   if (triggerSet.has(cleanMessage)) {
     if (!message.author.bot) {
-      message.reply("Nan toi ta gueule");
+      if (Math.random() < 0.01) {
+        message.reply("ok");
+      } else {
+        message.reply("Nan toi ta gueule");
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary
- respond with "ok" in place of "Nan toi ta gueule" 1% of the time for trigger phrases

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689c57474d6883339f630b429e72f6e8