### PR TITLE
Fix meme command video audio and retries

### DIFF
--- a/src/commands/meme.js
+++ b/src/commands/meme.js
@@ -3,14 +3,20 @@ const { fetchRandomMeme, downloadToDiscordAttachment } = require('../services/me
 module.exports = {
   name: 'meme',
   async execute(interaction) {
-    const meme = await fetchRandomMeme();
+    let meme = null;
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      meme = await fetchRandomMeme();
+      if (meme) break;
+    }
+
     if (!meme) {
-      await interaction.channel.send("https://tenor.com/view/kirby-i-forgot-i-forgor-gif-22449575");
+      await interaction.channel.send("Impossible de trouver un meme pour le moment, réessaie dans quelques secondes.");
       return;
     }
     try {
-      const file = await downloadToDiscordAttachment(meme.url, meme.type);
-      if (meme.type === 'image' || meme.type === 'video') {
+      if (meme.downloadUrl) {
+        const file = await downloadToDiscordAttachment(meme.downloadUrl, meme.type);
         await interaction.channel.send({ files: [file] });
       } else {
         await interaction.channel.send(meme.url);


### PR DESCRIPTION
## Summary
- retry the `/meme` command several times before giving up so it no longer posts the Kirby gif
- keep track of meme metadata to avoid duplicates while allowing direct links for Reddit videos so they keep their audio
- send files only when a downloadable URL is available and fall back to links for Reddit-hosted videos

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cc17f6b44c8333944d87568cca9cd8