### PR TITLE
Fix meme command video download

### DIFF
--- a/src/commands/meme.js
+++ b/src/commands/meme.js
@@ -16,9 +16,7 @@ module.exports = {
     }
     try {
       if (meme.downloadUrl) {
-        
-        const file = await downloadToDiscordAttachment(meme.downloadUrl, meme.type);
-
+        const file = await downloadToDiscordAttachment(meme);
         await interaction.channel.send({ files: [file] });
       } else {
         await interaction.channel.send(meme.url);

--- a/src/services/meme.js
+++ b/src/services/meme.js
@@ -85,18 +85,19 @@ async function fetchRandomMeme() {
     const url = post.url || '';
 
     if (post.is_video && post.media?.reddit_video?.fallback_url) {
-      const downloadUrl = post.media.reddit_video.fallback_url;
+      const fallbackUrl = post.media.reddit_video.fallback_url;
       const permalink = post.permalink
         ? `https://www.reddit.com${post.permalink}`
         : (url.includes('reddit.com') ? url : null);
-      const pageUrl = url || (post.permalink ? `https://www.reddit.com${post.permalink}` : downloadUrl);
+      const pageUrl = url || (post.permalink ? `https://www.reddit.com${post.permalink}` : fallbackUrl);
       return {
         type: 'reddit_video',
         url: pageUrl,
-        downloadUrl: null,
-        cacheKey: downloadUrl,
+        downloadUrl: fallbackUrl,
+        cacheKey: fallbackUrl,
         title: post.title,
-        subreddit: sub
+        subreddit: sub,
+        permalink
       };
     }
 


### PR DESCRIPTION
## Summary
- fix the /meme command so it downloads attachments using the meme object
- include Reddit permalinks and fallback URLs so videos are downloadable and cached

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1313d4fc083339191a96b491148f5